### PR TITLE
Added aria-label to button.hestia-scroll-to-top

### DIFF
--- a/inc/views/blog/class-hestia-additional-views.php
+++ b/inc/views/blog/class-hestia-additional-views.php
@@ -171,7 +171,7 @@ class Hestia_Additional_Views extends Hestia_Abstract_Main {
 			return;
 		}
 		?>
-		<button class="hestia-scroll-to-top">
+		<button class="hestia-scroll-to-top" aria-label="Scroll to Top">
 			<i class="fa fa-angle-double-up" aria-hidden="true"></i>
 		</button>
 		<?php


### PR DESCRIPTION
When performing a Lighthouse audit on the site it marks down on the accessibility section with the following. Adding a `aria-label` will allow all screen readers to read the button correctly.

> When a button doesn't have an accessible name, screen readers announce it as "button", making it unusable for users who rely on screen readers. [Learn more](https://web.dev/button-name/?utm_source=lighthouse&utm_medium=devtools).