### PR TITLE
WCAG Level A Warning

### DIFF
--- a/inc/class-hestia-bootstrap-navwalker.php
+++ b/inc/class-hestia-bootstrap-navwalker.php
@@ -29,7 +29,7 @@ class Hestia_Bootstrap_Navwalker extends Walker_Nav_Menu {
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
 		$indent  = str_repeat( "\t", $depth );
-		$output .= "\n$indent<ul role=\"menu\" class=\"dropdown-menu\">\n";
+		$output .= "\n$indent<ul class=\"dropdown-menu\">\n";
 	}
 
 	/**


### PR DESCRIPTION
Elements with role=menu must contain or own an element with role=menuitem or role=menuitemcheckbox or role=menuitemradio.