### PR TITLE
Update load.php - fix Warning thrown

### DIFF
--- a/vendor/codeinwp/themeisle-sdk/load.php
+++ b/vendor/codeinwp/themeisle-sdk/load.php
@@ -24,9 +24,11 @@ global $themeisle_sdk_max_path;
 $themeisle_sdk_relative_licenser_path = '/src/Modules/Licenser.php';
 
 global $themeisle_sdk_abs_licenser_path;
-if ( ! is_file( $themeisle_sdk_path . $themeisle_sdk_relative_licenser_path ) && is_file( $themeisle_sdk_max_path . $themeisle_sdk_relative_licenser_path ) ) {
-	$themeisle_sdk_abs_licenser_path = $themeisle_sdk_max_path . $themeisle_sdk_relative_licenser_path;
-	add_filter( 'themeisle_sdk_required_files', 'themeisle_sdk_load_licenser_if_present' );
+if (!empty($themeisle_sdk_max_path)) {
+	if ( ! file_exists( $themeisle_sdk_path . $themeisle_sdk_relative_licenser_path ) && file_exists( $themeisle_sdk_max_path . $themeisle_sdk_relative_licenser_path ) ) {
+		$themeisle_sdk_abs_licenser_path = $themeisle_sdk_max_path . $themeisle_sdk_relative_licenser_path;
+		add_filter( 'themeisle_sdk_required_files', 'themeisle_sdk_load_licenser_if_present' );
+	}
 }
 if ( version_compare( $themeisle_sdk_version, $themeisle_sdk_max_path ) == 0 &&
 	apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {


### PR DESCRIPTION
$themeisle_sdk_max_version variable is not set and because of that
“Warning: is_file(): open_basedir restriction in effect. File(/src/Modules/Licenser.php) is not within the allowed path(s):"
is thrown as the script is trying to access 
“/src/Modules/Licenser.php” in line 27, 
instead of
 “__DIR__/src/Modules/Licenser.php”